### PR TITLE
Allow composition of fragment macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Wrapped the Ecto.Query macros in parentheses to allow composition like `1 - cosine_distance(x, y)`
+
 ## 0.1.2 (2022-08-26)
 
 - Added distance functions for Ecto

--- a/lib/pgvector/ecto/query.ex
+++ b/lib/pgvector/ecto/query.ex
@@ -2,19 +2,19 @@ if Code.ensure_loaded?(Ecto) do
   defmodule Pgvector.Ecto.Query do
     defmacro l2_distance(column, value) do
       quote do
-        fragment("? <-> ?::vector", unquote(column), unquote(value))
+        fragment("(? <-> ?::vector)", unquote(column), unquote(value))
       end
     end
 
     defmacro max_inner_product(column, value) do
       quote do
-        fragment("? <#> ?::vector", unquote(column), unquote(value))
+        fragment("(? <#> ?::vector)", unquote(column), unquote(value))
       end
     end
 
     defmacro cosine_distance(column, value) do
       quote do
-        fragment("? <=> ?::vector", unquote(column), unquote(value))
+        fragment("(? <=> ?::vector)", unquote(column), unquote(value))
       end
     end
   end

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -40,5 +40,9 @@ defmodule EctoTest do
 
     items = Repo.all(from i in Item, order_by: cosine_distance(i.factors, [1, 1, 1]), limit: 5)
     assert Enum.map(items, fn v -> v.id end) == [1, 2, 3]
+
+    # Macros allow composition, like deriving the cosine similarity from the cosine distance.
+    items = Repo.all(from i in Item, order_by: (1 - cosine_distance(i.factors, [1, 1, 1])), limit: 5)
+    assert Enum.map(items, fn v -> v.id end) == [3, 1, 2]
   end
 end


### PR DESCRIPTION
Hi @ankane ,

we found out that the `Pgvector.Ecto.Query` macros can't be composed with other operators as they're not in parentheses.

For instance, consider the following Elixir code:

```elixir
Repo.all(from i in Item, order_by: (1 - cosine_distance(i.factors, [1, 1, 1]))
```

This generates the following SQL (roughly):

```
SELECT * FROM items ORDER BY 1 - i.factors <=> '[1, 1, 1]'::vector;
```

However, since the `-` has stronger binding than the `<=>` operator, this leads to an error:

```
** (Postgrex.Error) ERROR 42883 (undefined_function) operator does not exist: integer - vector
```

This patch adds parentheses around the fragment expressions to fix this.

cheers,
malte