### PR TITLE
Delete pgvector.ex

### DIFF
--- a/lib/pgvector.ex
+++ b/lib/pgvector.ex
@@ -1,2 +1,0 @@
-defmodule Pgvector do
-end


### PR DESCRIPTION
There is no need to define the initial namespace
if it is not used.

---

Another minor change, no need to merge it if you'd rather
leave it there, although I don't expect nobody to depend on it.