### PR TITLE
Handle Pgvector itself in new/1

### DIFF
--- a/lib/pgvector.ex
+++ b/lib/pgvector.ex
@@ -6,8 +6,12 @@ defmodule Pgvector do
   defstruct [:data]
 
   @doc """
-  Creates a new vector from a list or tensor
+  Creates a new vector from a Pgvector or list or tensor
   """
+  def new(%Pgvector{} = pgvector) do
+    pgvector
+  end
+
   def new(list) when is_list(list) do
     dim = list |> length()
     bin = for v <- list, into: "", do: <<v::float-32>>

--- a/test/pgvector_test.exs
+++ b/test/pgvector_test.exs
@@ -1,6 +1,11 @@
 defmodule PgvectorTest do
   use ExUnit.Case
 
+  test "pgvector" do
+    pgvector = Pgvector.new([1, 2, 3])
+    assert pgvector == pgvector |> Pgvector.new()
+  end
+
   test "list" do
     list = [1.0, 2.0, 3.0]
     assert list == list |> Pgvector.new() |> Pgvector.to_list()


### PR DESCRIPTION
If you try to take `Pgvector` from A and update it in B, you will get the following error.

```elixir
** (FunctionClauseError) no function clause matching in Pgvector.new/1    
    
    The following arguments were given to Pgvector.new/1:
    
        # 1
        Pgvector.new([...])
    
    Attempted function clauses (showing 2 out of 2):
    
        def new(list) when is_list(list)
        def new(tensor) when is_struct(tensor, Nx.Tensor)
    
    (pgvector 0.2.0) lib/pgvector.ex:11: Pgvector.new/1
    (pgvector 0.2.0) lib/pgvector/ecto/vector.ex:8: Pgvector.Ecto.Vector.cast/1
    (ecto 3.10.3) lib/ecto/changeset.ex:814: Ecto.Changeset.cast_field/9
    (ecto 3.10.3) lib/ecto/changeset.ex:766: Ecto.Changeset.process_param/9
    (elixir 1.15.4) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ecto 3.10.3) lib/ecto/changeset.ex:744: Ecto.Changeset.cast/6
```

Since Elixir primitives like `URI` can receive themselves as a parameter of new function, `Pgvector` does the same thing.