### PR TITLE
Use to_doc when converting algebra documents

### DIFF
--- a/lib/pgvector.ex
+++ b/lib/pgvector.ex
@@ -135,6 +135,6 @@ defimpl Inspect, for: Pgvector do
   import Inspect.Algebra
 
   def inspect(vector, opts) do
-    concat(["Pgvector.new(", Inspect.List.inspect(Pgvector.to_list(vector), opts), ")"])
+    concat(["Pgvector.new(", to_doc(Pgvector.to_list(vector), opts), ")"])
   end
 end

--- a/lib/pgvector/half_vector.ex
+++ b/lib/pgvector/half_vector.ex
@@ -50,6 +50,6 @@ defimpl Inspect, for: Pgvector.HalfVector do
   import Inspect.Algebra
 
   def inspect(vector, opts) do
-    concat(["Pgvector.HalfVector.new(", Inspect.List.inspect(Pgvector.to_list(vector), opts), ")"])
+    concat(["Pgvector.HalfVector.new(", to_doc(Pgvector.to_list(vector), opts), ")"])
   end
 end

--- a/lib/pgvector/sparse_vector.ex
+++ b/lib/pgvector/sparse_vector.ex
@@ -101,9 +101,9 @@ defimpl Inspect, for: Pgvector.SparseVector do
 
     concat([
       "Pgvector.SparseVector.new(",
-      Inspect.Map.inspect(elements, opts),
+      to_doc(elements, opts),
       ", ",
-      Inspect.Integer.inspect(dimensions, opts),
+      to_doc(dimensions, opts),
       ")"
     ])
   end


### PR DESCRIPTION
Elixir v1.19 allows the inspect protocol to return a tuple {doc, opts}, so we use the official to_doc API for converting documents. This is backwards compatible.