### PR TITLE
Adds shortcut `cosine_similarity` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ import Pgvector.Ecto.Query
 Repo.all(from i in Item, order_by: l2_distance(i.embedding, ^Pgvector.new([1, 2, 3])), limit: 5)
 ```
 
-Also supports `max_inner_product`, `cosine_distance`, `l1_distance`, `hamming_distance`, and `jaccard_distance`
+Also supports `max_inner_product`, `cosine_distance` (and it's complement `cosine_similarity`), `l1_distance`, `hamming_distance`, and `jaccard_distance`
 
 Convert a vector to a list or Nx tensor
 
@@ -125,7 +125,7 @@ create index("items", ["embedding vector_l2_ops"], using: :hnsw)
 create index("items", ["embedding vector_l2_ops"], using: :ivfflat, options: "lists = 100")
 ```
 
-Use `vector_ip_ops` for inner product and `vector_cosine_ops` for cosine distance
+Use `vector_ip_ops` for inner product and `vector_cosine_ops` for cosine distance and cosine similarity
 
 ## Postgrex
 
@@ -180,7 +180,7 @@ Postgrex.query!(pid, "CREATE INDEX ON items USING hnsw (embedding vector_l2_ops)
 Postgrex.query!(pid, "CREATE INDEX ON items USING ivfflat (embedding vector_l2_ops) WITH (lists = 100)", [])
 ```
 
-Use `vector_ip_ops` for inner product and `vector_cosine_ops` for cosine distance
+Use `vector_ip_ops` for inner product and `vector_cosine_ops` for cosine distance and cosine similarity
 
 ## Reference
 

--- a/lib/pgvector/ecto/query.ex
+++ b/lib/pgvector/ecto/query.ex
@@ -32,6 +32,15 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     @doc """
+    Returns the cosine similarity
+    """
+    defmacro cosine_similarity(left, right) do
+      quote do
+        fragment("1 - (? <=> ?)", unquote(left), unquote(right))
+      end
+    end
+
+    @doc """
     Returns the L1 distance
     """
     defmacro l1_distance(left, right) do

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -46,7 +46,7 @@ defmodule EctoTest do
   end
 
   test "vector cosine similarity" do
-    items = Repo.all(from i in Item, order_by: (1 - cosine_distance(i.embedding, ^Pgvector.new([1, 1, 1]))), limit: 5)
+    items = Repo.all(from i in Item, order_by: cosine_similarity(i.embedding, ^Pgvector.new([1, 1, 1])), limit: 5)
     assert Enum.map(items, fn v -> v.id end) == [3, 2, 1]
   end
 
@@ -72,7 +72,7 @@ defmodule EctoTest do
   end
 
   test "halfvec cosine similarity" do
-    items = Repo.all(from i in Item, order_by: (1 - cosine_distance(i.half_embedding, ^Pgvector.HalfVector.new([1, 1, 1]))), limit: 5)
+    items = Repo.all(from i in Item, order_by: cosine_similarity(i.half_embedding, ^Pgvector.HalfVector.new([1, 1, 1])), limit: 5)
     assert Enum.map(items, fn v -> v.id end) == [3, 2, 1]
   end
 
@@ -108,7 +108,7 @@ defmodule EctoTest do
   end
 
   test "sparsevec cosine similarity" do
-    items = Repo.all(from i in Item, order_by: (1 - cosine_distance(i.sparse_embedding, ^Pgvector.SparseVector.new([1, 1, 1]))), limit: 5)
+    items = Repo.all(from i in Item, order_by: cosine_similarity(i.sparse_embedding, ^Pgvector.SparseVector.new([1, 1, 1])), limit: 5)
     assert Enum.map(items, fn v -> v.id end) == [3, 2, 1]
   end
 


### PR DESCRIPTION
Hi :wave: 

Thanks for this great useful package!

Thought this might help not only for the shortcut but also making clear for anyone looking at this for the first time (happened to me) that cosine distance is different (complement) of cosine similarity.

Thoughts?